### PR TITLE
Change cl-pushnew to push

### DIFF
--- a/whicher.el
+++ b/whicher.el
@@ -51,8 +51,7 @@
 Store it into `whicher-cmd-list'.
 Use `whicher-check' to check this list."
   (let ((program (car (split-string cmd-string))))
-    (cl-pushnew program whicher-cmd-list
-                :test #'string=))
+    (push program whicher-cmd-list))
   cmd-string)
 
 (defun whicher--progname (p)


### PR DESCRIPTION
Changed "cl-pushnew" to simply "push" to remove the depedency on the common lisp library. The function "push" in Emacs Lisp offers essentially the same functionality.